### PR TITLE
fix(export): change export templates folder name

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -26,8 +26,10 @@ jobs:
           ]
         include:
           # Different versions of Godot have different command line options,
-          # export_presets and project settings, so just export for this version.
+          # export_presets and project settings, so just export for these versions.
           - version: "v3.5.1-stable"
+            export-templates: true
+          - version: "v4.2.1-stable"
             export-templates: true
         exclude:
           - os: macos-12
@@ -65,13 +67,14 @@ jobs:
         if: ${{ matrix.export-templates == true }}
         working-directory: test_project
         shell: bash
-        run: godot --no-window --export ${{ matrix.os }}
+        # v3 and v4 use --export and --export-<target> respectively.
+        run: godot --no-window --export ${{ matrix.os }} || godot --headless --export-debug ${{ matrix.os }}
       - name: Run exported project (linux)
         if: ${{ matrix.export-templates == true && matrix.os == 'ubuntu-latest' }}
         working-directory: test_project
         run: |
-          ./test
-          grep 'Test success!' ~/.local/share/godot/app_userdata/test/test.log
+          ./test --rendering-driver opengl3
+          grep 'Test success!' ~/.local/share/godot/app_userdata/test/test.log || grep 'Test success!' ~/.local/share/godot/app_userdata/test/logs/godot.log
       - name: Run exported project (macos)
         if: ${{ matrix.export-templates == true && matrix.os == 'macos-12' }}
         working-directory: test_project

--- a/lib/Linux.js
+++ b/lib/Linux.js
@@ -83,7 +83,7 @@ class Linux extends Platform {
   }
 
   _getExportTemplatesDir() {
-    return process.env.HOME + "/.local/share/godot/templates";
+    return `${process.env.HOME}/.local/share/godot/${this.exportTemplatesFolderName}`;
   }
 
   async _getSymlinkTarget() {

--- a/lib/MacOS.js
+++ b/lib/MacOS.js
@@ -32,7 +32,7 @@ class MacOS extends Platform {
   }
 
   _getExportTemplatesDir() {
-    return process.env.HOME + "/Library/Application Support/Godot/templates";
+    return `${process.env.HOME}/Library/Application Support/Godot/${this.exportTemplatesFolderName}`;
   }
 
   async _getSymlinkTarget() {

--- a/lib/Platform.js
+++ b/lib/Platform.js
@@ -22,6 +22,7 @@ class Platform {
   suffix;
   downloadUrl;
   exportTemplatesUrl;
+  exportTemplatesFolderName;
   installDir;
 
   constructor() {
@@ -51,6 +52,11 @@ class Platform {
       throw new Error("Failed to detect version");
     this.version = result.groups.version;
     this.release = result.groups.release || "stable";
+
+    const version = semver.coerce(`${this.version}-${this.release}`);
+    this.exportTemplatesFolderName = semver.gte(version, "4.0.0-beta1")
+      ? "export_templates"
+      : "templates";
 
     core.info(
       `Detected version: v${this.version}-${this.release} ${this.bits}bit ${

--- a/lib/Windows.js
+++ b/lib/Windows.js
@@ -111,7 +111,7 @@ class Windows extends Platform {
   }
 
   _getExportTemplatesDir() {
-    return process.env.APPDATA + "/Godot/templates";
+    return `${process.env.APPDATA}/Godot/${this.exportTemplatesFolderName}`;
   }
 
   async _getSymlinkTarget() {


### PR DESCRIPTION
As of https://github.com/godotengine/godot/commit/73c11ab31ade9acc894f46e936477e98e1b5f3e3, the export templates folder name was changed from 'templates' to 'export_templates'.