### PR TITLE
Use GitHub for Godot downloads

### DIFF
--- a/lib/Platform.js
+++ b/lib/Platform.js
@@ -68,17 +68,12 @@ class Platform {
   }
 
   getDownloadUrl(filename) {
-    // As of 3.4-stable, stable releases are now mirrored on the godotengine github repo.
     const version = semver.coerce(`${this.version}-${this.release}`);
 
     let subdir = this.release === "stable" ? "" : `/${this.release}`;
     if (this.mono) subdir += "/mono";
 
-    if (this.release === "stable" && semver.gte(version, "3.4.0-stable")) {
-      return `https://github.com/godotengine/godot/releases/download/${this.version}-stable/${filename}`;
-    } else {
-      return `https://downloads.tuxfamily.org/godotengine/${this.version}${subdir}/${filename}`;
-    }
+    return `https://github.com/godotengine/godot/releases/download/${this.version}-stable/${filename}`;
   }
 
   async preDownload() {


### PR DESCRIPTION
TuxFamily is no longer reliable.